### PR TITLE
Allow rootlogon to run without /home/trholmes, and adjust README to match scripts docstrings

### DIFF
--- a/.rootlogon.C
+++ b/.rootlogon.C
@@ -2,6 +2,9 @@
     printf("Running rootlogon.C\n");
     //gROOT->LoadMacro("/home/trholmes/utils/tdrstyle.C"); 
     //setTDRStyle();
-    gROOT->LoadMacro("/home/trholmes/utils/AtlasStyle.C");
-    SetAtlasStyle();
+    if (gROOT->LoadMacro("/home/trholmes/utils/AtlasStyle.C") == 0) {
+      SetAtlasStyle();
+    } else {
+      printf("Canceling rootlogon.C\n");
+    }
 }

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Collection of scripts for performing Muon Collider studies. These scripts assume
 
 ```
 apptainer build k4toroid.sif docker://madbaron/k4test-ubuntu:latest
-apptainer run --no-home -B /tank/data/snowmass21/muonc:/data -B /home/$USER -B /work/$USER /home/$USER/mucol/k4toroid.sif
+apptainer run --no-home -B /tank/data/snowmass21/muonc:/data -B /home/$USER -B /work/$USER k4toroid.sif
 ```
 
 and then from inside the image, run:


### PR DESCRIPTION
cc @trholmes 🍉 

When running `makeMuonPlots_k4hep.py`:

1. I bumped on `/home/trholmes` in `.rootlogon.C`, which I didn't have access to.

```
Apptainer> python makeMuonPlots_k4hep.py
Running rootlogon.C
Error in <TROOT::LoadMacro>: macro /home/trholmes/utils/AtlasStyle.C not found in path .:/opt/spack/opt/spack/linux-ubuntu22.04-x86_64/gcc-11.3.0/root-6.28.02-67zd35p6a6ujklkrec5whddkmbsekypu/share/root/macros
input_line_37:2:3: error: use of undeclared identifier 'SetAtlasStyle'
 (SetAtlasStyle())
```

2. The `apptainer build/run` commands in the README right now are a mix of relative [0] and absolute [1] paths for the `.sif` file. I bumped on this because I ran `apptainer build` in some random directory. The scripts [2] which mention apptainer use relative paths, so I changed README to use relative paths, for consistency.

[0] `apptainer build` uses `k4toroid.sif`
[1] `apptainer run` uses `/home/$USER/mucol/k4toroid.sif`
[2] `pfoStudies.py`, `makeMuonPlots_k4hep.py`, `electronStudies.py`

PS. Please forgive my insufferable use of "I bumped on" 
